### PR TITLE
feat(user): PATCH /users/me partial profile update with preferences

### DIFF
--- a/src/app/user/application/dtos/requests/patch-user-profile.request.dto.ts
+++ b/src/app/user/application/dtos/requests/patch-user-profile.request.dto.ts
@@ -1,0 +1,84 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsBoolean, IsDate, IsEmail, IsMobilePhone, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+
+export type PatchUserProfileFields = {
+  firstname?: string;
+  lastname?: string;
+  email?: string;
+  mobileNumber?: string;
+  birthdate?: Date;
+  language?: string;
+  emailReminders?: boolean;
+  smsReminders?: boolean;
+};
+
+export class PatchUserProfileRequestDto {
+  @ApiPropertyOptional({ description: 'The first name.', type: String, example: 'John' })
+  @IsOptional()
+  @IsString()
+  @MinLength(2)
+  @MaxLength(50)
+  public firstname?: string;
+
+  @ApiPropertyOptional({ description: 'The last name.', type: String, example: 'Doe' })
+  @IsOptional()
+  @IsString()
+  @MinLength(2)
+  @MaxLength(50)
+  public lastname?: string;
+
+  @ApiPropertyOptional({ description: 'The email address.', type: String, example: 'example@email.com' })
+  @IsOptional()
+  @IsEmail()
+  public email?: string;
+
+  @ApiPropertyOptional({ description: 'The mobile number.', type: String, example: '+21699111222' })
+  @IsOptional()
+  @IsMobilePhone()
+  public mobileNumber?: string;
+
+  @ApiPropertyOptional({ description: 'The date of birth.', type: String, example: '2005-04-03' })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  public birthdate?: Date;
+
+  @ApiPropertyOptional({ description: 'The preferred language.', type: String, example: 'French' })
+  @IsOptional()
+  @IsString()
+  @MinLength(2)
+  @MaxLength(50)
+  public language?: string;
+
+  @ApiPropertyOptional({ description: 'Whether the user receives reminders by email.', type: Boolean, example: true })
+  @IsOptional()
+  @IsBoolean()
+  public emailReminders?: boolean;
+
+  @ApiPropertyOptional({ description: 'Whether the user receives reminders by SMS.', type: Boolean, example: true })
+  @IsOptional()
+  @IsBoolean()
+  public smsReminders?: boolean;
+
+  public hasAnyUpdatableField(): boolean {
+    return Object.keys(this.definedEntries()).length > 0;
+  }
+
+  public definedEntries(): PatchUserProfileFields {
+    const fields: PatchUserProfileFields = {
+      firstname: this.firstname,
+      lastname: this.lastname,
+      email: this.email,
+      mobileNumber: this.mobileNumber,
+      birthdate: this.birthdate,
+      language: this.language,
+      emailReminders: this.emailReminders,
+      smsReminders: this.smsReminders,
+    };
+
+    return Object.fromEntries(
+      Object.entries(fields).filter(([, value]) => value !== undefined),
+    ) as PatchUserProfileFields;
+  }
+}

--- a/src/app/user/application/dtos/responses/user.response.dto.ts
+++ b/src/app/user/application/dtos/responses/user.response.dto.ts
@@ -74,6 +74,20 @@ export class UserResponseDto {
   public language: string;
 
   @ApiProperty({
+    description: 'Whether the user receives reminders by email.',
+    type: Boolean,
+    example: true,
+  })
+  public emailReminders: boolean;
+
+  @ApiProperty({
+    description: 'Whether the user receives reminders by SMS.',
+    type: Boolean,
+    example: true,
+  })
+  public smsReminders: boolean;
+
+  @ApiProperty({
     description: 'The saloons the user has access to.',
     type: [String],
     example: ['a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11-Owner', 'a0eebc95-9c0b-4ef8-bb6d-6bb9bd380a11-Owner'],
@@ -95,6 +109,8 @@ export class UserResponseDto {
     userResponse.createdAt = user.createdAt;
     userResponse.updatedAt = user.updatedAt;
     userResponse.language = user.language;
+    userResponse.emailReminders = user.emailReminders;
+    userResponse.smsReminders = user.smsReminders;
 
     userResponse.saloons = user.acl;
 

--- a/src/app/user/application/transformers/user.transformer.ts
+++ b/src/app/user/application/transformers/user.transformer.ts
@@ -14,6 +14,8 @@ export class UserTransformer {
     user.mobileNumber = userRequest.mobileNumber;
     user.password = userRequest.password;
     user.language = userRequest.language;
+    user.emailReminders = true;
+    user.smsReminders = true;
 
     user.acl = [];
 

--- a/src/app/user/application/usecases/patch-user-profile.usecase.ts
+++ b/src/app/user/application/usecases/patch-user-profile.usecase.ts
@@ -1,0 +1,139 @@
+import {
+  PatchUserProfileFields,
+  PatchUserProfileRequestDto,
+} from '@user/application/dtos/requests/patch-user-profile.request.dto';
+import { UserResponseDto } from '@user/application/dtos/responses/user.response.dto';
+import { User } from '@user/domain/entities/user';
+import { IUserRepository, USERS_REPOSITORY } from '@user/domain/ports/iuser.repository';
+import {
+  ConflictException,
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+
+@Injectable()
+export class PatchUserProfileUseCase {
+  private readonly logger = new Logger(PatchUserProfileUseCase.name);
+
+  constructor(@Inject(USERS_REPOSITORY) private readonly userRepository: IUserRepository) {}
+
+  async execute(userId: string, dto: PatchUserProfileRequestDto): Promise<UserResponseDto> {
+    const patch = dto.definedEntries();
+
+    if (!dto.hasAnyUpdatableField()) {
+      throw new UnprocessableEntityException('At least one updatable field must be provided.');
+    }
+
+    const user = await this.userRepository.findOneById(userId);
+
+    if (!user) {
+      throw new NotFoundException('User not found.');
+    }
+
+    await this.assertEmailIsUnique(dto.email, user.id, user.email);
+
+    const changedFields = this.extractChangedFields(user, patch);
+
+    if (changedFields.length === 0) {
+      throw new UnprocessableEntityException('No profile changes were provided.');
+    }
+
+    this.applyPatch(user, patch);
+    user.updatedAt = new Date();
+
+    let updatedUser: User;
+
+    try {
+      updatedUser = await this.userRepository.update(user);
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('duplicate key')) {
+        throw new ConflictException('A user with the same email and/or mobileNumber already exists.');
+      }
+
+      throw new InternalServerErrorException('Failed to update profile.');
+    }
+
+    this.logger.log(
+      JSON.stringify({
+        event: 'user.profile.patch',
+        userId,
+        changedFields,
+      }),
+    );
+
+    return UserResponseDto.createFromEntity(updatedUser);
+  }
+
+  private async assertEmailIsUnique(
+    newEmail: string | undefined,
+    currentUserId: string,
+    currentEmail: string,
+  ): Promise<void> {
+    if (!newEmail || newEmail === currentEmail) {
+      return;
+    }
+
+    const existingUser = await this.userRepository.findOneByEmail(newEmail);
+
+    if (existingUser && existingUser.id !== currentUserId) {
+      throw new ConflictException('A user with this email already exists.');
+    }
+  }
+
+  private extractChangedFields(user: User, patch: PatchUserProfileFields): string[] {
+    const changedFields: string[] = [];
+
+    if (patch.firstname !== undefined && patch.firstname !== user.firstname) {
+      changedFields.push('firstname');
+    }
+
+    if (patch.lastname !== undefined && patch.lastname !== user.lastname) {
+      changedFields.push('lastname');
+    }
+
+    if (patch.email !== undefined && patch.email !== user.email) {
+      changedFields.push('email');
+    }
+
+    if (patch.mobileNumber !== undefined && patch.mobileNumber !== user.mobileNumber) {
+      changedFields.push('mobileNumber');
+    }
+
+    if (patch.birthdate !== undefined && !this.isSameDate(patch.birthdate, user.birthdate)) {
+      changedFields.push('birthdate');
+    }
+
+    if (patch.language !== undefined && patch.language !== user.language) {
+      changedFields.push('language');
+    }
+
+    if (patch.emailReminders !== undefined && patch.emailReminders !== user.emailReminders) {
+      changedFields.push('emailReminders');
+    }
+
+    if (patch.smsReminders !== undefined && patch.smsReminders !== user.smsReminders) {
+      changedFields.push('smsReminders');
+    }
+
+    return changedFields;
+  }
+
+  private applyPatch(user: User, patch: PatchUserProfileFields): void {
+    if (patch.firstname !== undefined) user.firstname = patch.firstname;
+    if (patch.lastname !== undefined) user.lastname = patch.lastname;
+    if (patch.email !== undefined) user.email = patch.email;
+    if (patch.mobileNumber !== undefined) user.mobileNumber = patch.mobileNumber;
+    if (patch.birthdate !== undefined) user.birthdate = patch.birthdate;
+    if (patch.language !== undefined) user.language = patch.language;
+    if (patch.emailReminders !== undefined) user.emailReminders = patch.emailReminders;
+    if (patch.smsReminders !== undefined) user.smsReminders = patch.smsReminders;
+  }
+
+  private isSameDate(a: Date, b: Date): boolean {
+    return a.getTime() === b.getTime();
+  }
+}

--- a/src/app/user/domain/entities/user.ts
+++ b/src/app/user/domain/entities/user.ts
@@ -14,6 +14,8 @@ export class User {
   public createdAt: Date;
   public updatedAt: Date;
   public language: string;
+  public emailReminders: boolean = true;
+  public smsReminders: boolean = true;
   public acl: string[] = [];
   public deletedAt?: Date;
 

--- a/src/app/user/infrastructure/controllers/user.controller.ts
+++ b/src/app/user/infrastructure/controllers/user.controller.ts
@@ -19,6 +19,7 @@ import {
   HttpCode,
   HttpStatus,
   Inject,
+  Patch,
   Param,
   Post,
   Put,
@@ -28,8 +29,10 @@ import {
 import { ApiBearerAuth, ApiBody, ApiConsumes, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { UpdateAvatarUsecase } from '@user/application/usecases/update-avatar.usecase';
 import { UpdateAvatarDto } from '@user/application/dtos/requests/update-avatar.dto';
+import { PatchUserProfileUseCase } from '@user/application/usecases/patch-user-profile.usecase';
+import { PatchUserProfileRequestDto } from '@user/application/dtos/requests/patch-user-profile.request.dto';
+import { MultipartFile } from '@shared/uploads/domain/interfaces/multipart-file.interface';
 import { FastifyRequest } from 'fastify';
-import type { MultipartFile as FastifyMultipartFile } from '@fastify/multipart';
 
 @ApiTags('Users')
 @Controller('users')
@@ -39,6 +42,7 @@ export class UserController {
     private readonly getUserInfoUsecase: GetUserInfoUsecase,
     private readonly deleteUserUseCase: DeleteUserAccountUseCase,
     @Inject(UpdateAvatarUsecase) private readonly updateAvatar: UpdateAvatarUsecase,
+    private readonly patchUserProfileUseCase: PatchUserProfileUseCase,
   ) {}
 
   @ApiOperation({ summary: 'Register a new user' })
@@ -129,6 +133,44 @@ export class UserController {
     await this.deleteUserUseCase.execute(userId);
   }
 
+  @ApiOperation({ summary: 'Partially update current user profile.' })
+  @ApiBearerAuth()
+  @ApiBody({
+    type: PatchUserProfileRequestDto,
+    examples: {
+      patchNameAndLanguage: {
+        summary: 'Update only first name and language',
+        value: {
+          firstname: 'Jane',
+          language: 'English',
+          emailReminders: true,
+          smsReminders: false,
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Profile updated successfully.',
+    type: UserResponseDto,
+  })
+  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'Validation failed.' })
+  @ApiResponse({
+    status: HttpStatus.UNPROCESSABLE_ENTITY,
+    description: 'Patch payload is empty or has no effective change.',
+  })
+  @ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'User should be logged in.' })
+  @ApiResponse({ status: HttpStatus.CONFLICT, description: 'Email and/or mobile number already in use.' })
+  @ApiResponse({ status: HttpStatus.INTERNAL_SERVER_ERROR, description: 'Something went wrong, try again.' })
+  @Patch('/me')
+  @Header('Content-Type', 'application/json')
+  async patchProfile(
+    @CurrentUser() user: User,
+    @Body(new ValidationPipe({ transform: true })) request: PatchUserProfileRequestDto,
+  ): Promise<UserResponseDto> {
+    return await this.patchUserProfileUseCase.execute(user.id, request);
+  }
+
   @Put('profile/avatar')
   @ApiOperation({ summary: 'Update user avatar' })
   @ApiBearerAuth()
@@ -153,7 +195,7 @@ export class UserController {
   @HttpCode(HttpStatus.NO_CONTENT)
   public async uploadAvatar(
     @CurrentUser() user: User,
-    @Req() req: FastifyRequest & { file: () => Promise<FastifyMultipartFile | undefined> },
+    @Req() req: FastifyRequest & { file: () => Promise<MultipartFile | undefined> },
   ): Promise<void> {
     const filePart = await req.file();
 

--- a/src/app/user/infrastructure/mappers/user.mapper.ts
+++ b/src/app/user/infrastructure/mappers/user.mapper.ts
@@ -17,6 +17,8 @@ export class UserMapper {
     user.createdAt = createdUser.createdAt;
     user.updatedAt = createdUser.updatedAt;
     user.language = createdUser.language;
+    user.emailReminders = createdUser.emailReminders;
+    user.smsReminders = createdUser.smsReminders;
     user.acl = createdUser.acl;
     user.status = createdUser.status;
     user.deletedAt = createdUser.deletedAt;
@@ -35,6 +37,8 @@ export class UserMapper {
     entity.mobileNumber = user.mobileNumber;
     entity.password = user.password;
     entity.language = user.language;
+    entity.emailReminders = user.emailReminders;
+    entity.smsReminders = user.smsReminders;
     entity.acl = user.acl;
     entity.deletedAt = user.deletedAt;
     entity.status = user.status;

--- a/src/app/user/infrastructure/modules/user.module.ts
+++ b/src/app/user/infrastructure/modules/user.module.ts
@@ -23,6 +23,7 @@ import { SalonMembership } from '@user/infrastructure/schemas/salon-membership.s
 import { ResetPasswordUseCase } from '@user/application/usecases/reset-password.usecase';
 import { Salon } from '@salon/infrastructure/schemas/salon.entity';
 import { UpdateAvatarUsecase } from '@user/application/usecases/update-avatar.usecase';
+import { PatchUserProfileUseCase } from '@user/application/usecases/patch-user-profile.usecase';
 
 import { NotificationModule } from '@notification/infrastructure/modules/notification.module';
 import { TokensModule } from '@token/infrastructure/modules/token.module';
@@ -79,6 +80,7 @@ import { FileModule } from '@shared/uploads/infrastructure/modules/file.module';
     ForgotPasswordUseCase,
     ResetPasswordUseCase,
     UpdateAvatarUsecase,
+    PatchUserProfileUseCase,
 
     //  helpers
     UserTransformer,

--- a/src/app/user/infrastructure/schemas/user.schema.ts
+++ b/src/app/user/infrastructure/schemas/user.schema.ts
@@ -41,6 +41,12 @@ export class User {
   @Column({ type: 'varchar', length: 50 })
   language: string;
 
+  @Column({ type: 'boolean', name: 'email_reminders', default: true })
+  emailReminders: boolean;
+
+  @Column({ type: 'boolean', name: 'sms_reminders', default: true })
+  smsReminders: boolean;
+
   @Column({ type: 'enum', enum: UserRole, default: UserRole.CLIENT }) // defaulting to CLIENT for safety
   role: UserRole;
 

--- a/src/migrations/1753612215016-initial-schema.ts
+++ b/src/migrations/1753612215016-initial-schema.ts
@@ -58,6 +58,16 @@ export class InitialSchema1753612215016 implements MigrationInterface {
             length: '50',
           },
           {
+            name: 'email_reminders',
+            type: 'boolean',
+            default: true,
+          },
+          {
+            name: 'sms_reminders',
+            type: 'boolean',
+            default: true,
+          },
+          {
             name: 'role',
             type: 'varchar',
             length: '50',

--- a/src/test/user.patch-profile.e2e-spec.ts
+++ b/src/test/user.patch-profile.e2e-spec.ts
@@ -1,0 +1,164 @@
+import { AppModule } from '../app.module';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import request from 'supertest';
+
+describe('PATCH /users/me (e2e)', () => {
+  let app: INestApplication;
+  let httpServer: Parameters<typeof request>[0];
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+    await app.init();
+    await (app as NestFastifyApplication).getHttpAdapter().getInstance().ready();
+    httpServer = app.getHttpServer() as Parameters<typeof request>[0];
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns 401 when request is unauthenticated', async () => {
+    await request(httpServer).patch('/users/me').send({ firstname: 'Unauthenticated' }).expect(401);
+  });
+
+  it('returns 200 for valid partial update and persists values', async () => {
+    const suffix = `${Date.now()}-patch-1`;
+    const password = 'P@ssw0rd1';
+
+    const user = {
+      firstname: 'John',
+      lastname: 'Doe',
+      birthdate: new Date('2000-01-01'),
+      role: 'client',
+      email: `patch1-${suffix}@email.com`,
+      mobileNumber: '+21655555111',
+      password,
+      language: 'French',
+    };
+
+    await request(httpServer).post('/users').send(user).expect(201);
+
+    const login = await request(httpServer).post('/auth/login').send({ email: user.email, password }).expect(201);
+
+    const accessToken = (login.body as { accessToken: string }).accessToken;
+
+    const patchResponse = await request(httpServer)
+      .patch('/users/me')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ firstname: 'Jane', language: 'English', emailReminders: false, smsReminders: true })
+      .expect(200);
+
+    expect((patchResponse.body as { firstname: string }).firstname).toBe('Jane');
+    expect((patchResponse.body as { language: string }).language).toBe('English');
+    expect((patchResponse.body as { emailReminders: boolean }).emailReminders).toBe(false);
+    expect((patchResponse.body as { smsReminders: boolean }).smsReminders).toBe(true);
+
+    const currentUser = await request(httpServer)
+      .get('/users/me')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect((currentUser.body as { firstname: string }).firstname).toBe('Jane');
+    expect((currentUser.body as { language: string }).language).toBe('English');
+    expect((currentUser.body as { emailReminders: boolean }).emailReminders).toBe(false);
+    expect((currentUser.body as { smsReminders: boolean }).smsReminders).toBe(true);
+  });
+
+  it('returns 422 for empty patch request', async () => {
+    const suffix = `${Date.now()}-patch-2`;
+    const password = 'P@ssw0rd1';
+
+    const user = {
+      firstname: 'John',
+      lastname: 'Doe',
+      birthdate: new Date('2000-01-01'),
+      role: 'client',
+      email: `patch2-${suffix}@email.com`,
+      mobileNumber: '+21655555222',
+      password,
+      language: 'French',
+    };
+
+    await request(httpServer).post('/users').send(user).expect(201);
+
+    const login = await request(httpServer).post('/auth/login').send({ email: user.email, password }).expect(201);
+
+    const accessToken = (login.body as { accessToken: string }).accessToken;
+
+    await request(httpServer).patch('/users/me').set('Authorization', `Bearer ${accessToken}`).send({}).expect(422);
+  });
+
+  it('returns 400 for invalid email format', async () => {
+    const suffix = `${Date.now()}-patch-3`;
+    const password = 'P@ssw0rd1';
+
+    const user = {
+      firstname: 'John',
+      lastname: 'Doe',
+      birthdate: new Date('2000-01-01'),
+      role: 'client',
+      email: `patch3-${suffix}@email.com`,
+      mobileNumber: '+21655555333',
+      password,
+      language: 'French',
+    };
+
+    await request(httpServer).post('/users').send(user).expect(201);
+
+    const login = await request(httpServer).post('/auth/login').send({ email: user.email, password }).expect(201);
+
+    const accessToken = (login.body as { accessToken: string }).accessToken;
+
+    await request(httpServer)
+      .patch('/users/me')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ email: 'invalid-email' })
+      .expect(400);
+  });
+
+  it('returns 409 when updating email to an existing one', async () => {
+    const suffix = `${Date.now()}-patch-4`;
+    const password = 'P@ssw0rd1';
+
+    const userA = {
+      firstname: 'John',
+      lastname: 'Doe',
+      birthdate: new Date('2000-01-01'),
+      role: 'client',
+      email: `patch4a-${suffix}@email.com`,
+      mobileNumber: '+21655555444',
+      password,
+      language: 'French',
+    };
+
+    const userB = {
+      firstname: 'Alice',
+      lastname: 'Smith',
+      birthdate: new Date('2000-01-01'),
+      role: 'client',
+      email: `patch4b-${suffix}@email.com`,
+      mobileNumber: '+21655555555',
+      password,
+      language: 'French',
+    };
+
+    await request(httpServer).post('/users').send(userA).expect(201);
+    await request(httpServer).post('/users').send(userB).expect(201);
+
+    const login = await request(httpServer).post('/auth/login').send({ email: userA.email, password }).expect(201);
+
+    const accessToken = (login.body as { accessToken: string }).accessToken;
+
+    await request(httpServer)
+      .patch('/users/me')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ email: userB.email })
+      .expect(409);
+  });
+});

--- a/src/test/user.patch-profile.spec.ts
+++ b/src/test/user.patch-profile.spec.ts
@@ -1,0 +1,100 @@
+import { PatchUserProfileRequestDto } from '@user/application/dtos/requests/patch-user-profile.request.dto';
+import { PatchUserProfileUseCase } from '@user/application/usecases/patch-user-profile.usecase';
+import { User } from '@user/domain/entities/user';
+import { UserRole } from '@user/domain/enums/user-role.enum';
+import { MockUsersReporitory } from '@user/infrastructure/mock-repositories/user.mock.repository';
+import { ConflictException, UnprocessableEntityException } from '@nestjs/common';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+describe('PatchUserProfileUseCase', () => {
+  let userRepository: MockUsersReporitory;
+  let useCase: PatchUserProfileUseCase;
+
+  beforeEach(() => {
+    MockUsersReporitory.users = [];
+    userRepository = new MockUsersReporitory();
+    useCase = new PatchUserProfileUseCase(userRepository);
+  });
+
+  it('updates only provided fields and keeps non-provided fields unchanged', async () => {
+    const user = await userRepository.save(createUserEntity('user1@email.com', '+21611111111'));
+
+    const request = plainToInstance(PatchUserProfileRequestDto, {
+      firstname: 'Jane',
+      language: 'English',
+      emailReminders: false,
+    });
+
+    const response = await useCase.execute(user.id, request);
+
+    expect(response.firstname).toBe('Jane');
+    expect(response.language).toBe('English');
+    expect(response.lastname).toBe(user.lastname);
+    expect(response.email).toBe(user.email);
+    expect(response.mobileNumber).toBe(user.mobileNumber);
+    expect(response.emailReminders).toBe(false);
+    expect(response.smsReminders).toBe(true);
+  });
+
+  it('throws unprocessable entity when no updatable field is provided', async () => {
+    const user = await userRepository.save(createUserEntity('user2@email.com', '+21622222222'));
+
+    const request = plainToInstance(PatchUserProfileRequestDto, {});
+
+    await expect(useCase.execute(user.id, request)).rejects.toBeInstanceOf(UnprocessableEntityException);
+  });
+
+  it('throws conflict when updating to an existing email owned by another user', async () => {
+    const user1 = await userRepository.save(createUserEntity('user3@email.com', '+21633333333'));
+    await userRepository.save(createUserEntity('user4@email.com', '+21644444444'));
+
+    const request = plainToInstance(PatchUserProfileRequestDto, {
+      email: 'user4@email.com',
+    });
+
+    await expect(useCase.execute(user1.id, request)).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('validates invalid email format', async () => {
+    const request = plainToInstance(PatchUserProfileRequestDto, {
+      email: 'not-an-email',
+    });
+
+    const errors = await validate(request);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.property).toBe('email');
+    expect(errors[0]?.constraints).toHaveProperty('isEmail');
+  });
+
+  it('validates invalid mobile number format', async () => {
+    const request = plainToInstance(PatchUserProfileRequestDto, {
+      mobileNumber: '12-34-56',
+    });
+
+    const errors = await validate(request);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.property).toBe('mobileNumber');
+    expect(errors[0]?.constraints).toHaveProperty('isMobilePhone');
+  });
+});
+
+function createUserEntity(email: string, mobileNumber: string): User {
+  const user = new User();
+
+  user.firstname = 'John';
+  user.lastname = 'Doe';
+  user.birthdate = new Date('2000-01-01');
+  user.role = UserRole.CLIENT;
+  user.email = email;
+  user.mobileNumber = mobileNumber;
+  user.password = 'P@ssw0rd';
+  user.language = 'French';
+  user.emailReminders = true;
+  user.smsReminders = true;
+  user.acl = [];
+
+  return user;
+}


### PR DESCRIPTION
Summary  
Shipped authenticated partial profile updates for the current user via PATCH /users/me, including reminder prefs and tighter patch rules.

What This PR Delivers  
- Added a partial profile update endpoint for authenticated users (self only).  
- Added optional patch request fields for:  
  firstname  
  lastname  
  email  
  mobileNumber  
  birthdate  
  language  
  emailReminders  
  smsReminders  
- Added validation so only fields actually sent get validated.  
- Changed empty / no-op patch behavior to 422 Unprocessable Entity.  
- Kept format-style validation errors as 400 Bad Request.  
- Added conflict handling (409) for unique constraints (email/mobile).  
- Added structured logging that only records the fields that changed.  
- Updated Swagger docs for request/response/error shapes.

Data Model / Persistence Updates  
Added reminder preferences as booleans, defaulting to true:  
- emailReminders  
- smsReminders  
Updated the domain model, schema, mapper, response mapping, and base migration source to match.  
And language stays a plain string (no enum in this PR).

Behavior Notes  
The endpoint only updates the fields included in the request.  
Anything not provided stays as-is.  
Avatar changes are still handled by the separate avatar endpoint.  
Route scope here is self-service only (/users/me). Not admin.

Testing  
Typecheck is clean.  
Patch profile unit tests are passing.  
An E2E patch test file is included/updated for:  
- 200 partial update  
- 422 empty patch  
- 400 validation failure  
- 409 conflict  
- 401 unauthorized (covered in scenarios)